### PR TITLE
Fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node": ">=10"
   },
   "scripts": {
-    "test": "ava",
+    "test": "nyc ava",
     "lint": "xo",
     "pretest": "npm run lint",
     "release": "np"

--- a/test/expected/code.html
+++ b/test/expected/code.html
@@ -3,4 +3,3 @@
   console.log(&quot;Hello&quot;)
 }
 </code></pre>
-

--- a/test/expected/importing.html
+++ b/test/expected/importing.html
@@ -1,3 +1,2 @@
 <h1>Hello there</h1>
 <h2>Imported content should be above me</h2>
-

--- a/test/expected/md-options.html
+++ b/test/expected/md-options.html
@@ -1,2 +1,1 @@
 <p><a href="https://example.com">https://example.com</a></p>
-

--- a/test/expected/md-plugin.html
+++ b/test/expected/md-plugin.html
@@ -1,2 +1,1 @@
 <p>You can use emojis 😃</p>
-


### PR DESCRIPTION
- added back coverage reporter
- fixed line endings in test files

@TheComputerM please fix line endings in your editor. If using VS Code, it's shown on the bottom right. All test fixtures need to be LF (not CRLF) in order for tests to pass.

Also, `nyc` is used to for coverage reports, please don't remove it so that we know how much of the code is covered by tests 🙂