### PR TITLE
Enable loading plugins from .posthtmlrc

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,6 +45,11 @@ module.exports = options => {
 
   // Add plugins to markdownParser
   for (const plugin of settings.plugins) {
+    if (typeof plugin.plugin === 'string') {
+      let loaded = require(plugin.plugin)
+      plugin.plugin = loaded.default || loaded;
+    }
+
     md.use(plugin.plugin, plugin.options || {})
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -85,9 +85,11 @@ module.exports = options => {
           content += importMarkdown(src, settings)
 
           if (tree.messages) {
+            const from = path.resolve(settings.root, src)
+
             tree.messages.push({
               type: 'dependency',
-              file: src
+              file: from
             })
           }
 


### PR DESCRIPTION
posthtml-markdownit assumes that posthtml is configured via JavaScript and not the .posthtmlrc configuration file. This change enables loading the plugins if they are defined as strings and enables .posthtmlrc configuration.