### PR TITLE
Return correct source path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -80,9 +80,11 @@ module.exports = options => {
           content += importMarkdown(src, settings)
 
           if (tree.messages) {
+            const from = path.resolve(settings.root, src)
+
             tree.messages.push({
               type: 'dependency',
-              file: src
+              file: from
             })
           }
 


### PR DESCRIPTION
If root is set to something other than the current working directory, posthtml will error out due to the file not being found. Making sure to prepend the correct root to the dependency message fixes this.